### PR TITLE
Add engine factory

### DIFF
--- a/src/StringTemplate/AbstractEngine.php
+++ b/src/StringTemplate/AbstractEngine.php
@@ -21,7 +21,7 @@ namespace StringTemplate;
  * //Prints "This is b and these are d and e"
  * </code>
  */
-abstract class AbstractEngine
+abstract class AbstractEngine implements EngineInterface
 {
     protected $left;
     protected $right;

--- a/src/StringTemplate/EngineFactory.php
+++ b/src/StringTemplate/EngineFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace StringTemplate;
+
+/**
+ * EngineFactory
+ */
+abstract class EngineFactory
+{
+    /**
+     * @param string $name
+     *
+     * @return EngineInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function create($name = 'regular')
+    {
+        $name = (string) $name;
+        $mapping = static::getMapping();
+
+        if (!isset($mapping[$name])) {
+            throw new \InvalidArgumentException(sprintf('Unrecognized "%s" engine', $name));
+        }
+
+        $className = $mapping[$name];
+        return new $className();
+    }
+
+    /**
+     * @return array
+     */
+    protected static function getMapping()
+    {
+        return array(
+            'regular' => 'StringTemplate\Engine',
+            'sprintf' => 'StringTemplate\SprintfEngine'
+        );
+    }
+}

--- a/src/StringTemplate/EngineInterface.php
+++ b/src/StringTemplate/EngineInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace StringTemplate;
+
+/**
+ * EngineInterface
+ */
+interface EngineInterface
+{
+    /**
+     * @param string $template      The template string
+     * @param string|array $value   The value the template will be rendered with
+     *
+     * @return string The rendered template
+     */
+    public function render($template, $value);
+}

--- a/tests/StringTemplate/EngineFactoryTest.php
+++ b/tests/StringTemplate/EngineFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace StringTemplate\Test;
+
+use StringTemplate\EngineFactory;
+
+/**
+ * Unit tests for the factory
+ */
+class EngineFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testUnrecognizedEngine()
+    {
+        EngineFactory::create('test');
+    }
+
+    public function testDefault()
+    {
+        $this->assertInstanceOf('StringTemplate\Engine', EngineFactory::create());
+    }
+
+    public function testRegular()
+    {
+        $this->assertInstanceOf('StringTemplate\Engine', EngineFactory::create('regular'));
+    }
+
+    public function testSprintf()
+    {
+        $this->assertInstanceOf('StringTemplate\SprintfEngine', EngineFactory::create('sprintf'));
+    }
+}


### PR DESCRIPTION
This makes more convenient to use the string template.

Instead of:

``` php
$engine = new StringTemplate\Engine();
$enginer->render(...);
```

Can be used:

``` php
EngineFactory::create()->render(...);
```

If you see other libs that are similar:
https://github.com/jalet/util-sprintf-php

The way of use is really simple:

```
Sprintf::f("My cat is %color%.", array('color' => 'brown'));
```

I prefer StringTemplate over that one, but I would prefer a more convenient way to use it, at least a factory.

Note: I didn't put any license on header of new files, because on code base there are 2 types of headers, so didn't know which one to use.
