### PR TITLE
autoload-dev for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
     },
     "autoload": {
         "psr-0": {
-            "StringTemplate": "src/",
+            "StringTemplate": "src/"
+        }
+    },
+    "autoload-dev":{
+        "psr-0": {
             "StringTemplate\\Test": "tests"
         }
     }


### PR DESCRIPTION
> Classes needed to run the test suite should not be included in the main autoload rules to avoid polluting the autoloader in production and when other people use your package as a dependency.

from: [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev)