### PR TITLE
fix: omits PHP 8.1 deprecation warnings

### DIFF
--- a/src/StringTemplate/NestedKeyArray.php
+++ b/src/StringTemplate/NestedKeyArray.php
@@ -28,6 +28,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new NestedKeyIterator(new RecursiveArrayOnlyIterator($this->array));
@@ -36,6 +37,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $keys = explode($this->keySeparator, $offset);
@@ -53,6 +55,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $keys = explode($this->keySeparator, $offset);
@@ -68,6 +71,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->setNestedOffset($this->array, explode($this->keySeparator, $offset), $value);
@@ -76,6 +80,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->unsetNestedOffset($this->array, explode($this->keySeparator, $offset));

--- a/src/StringTemplate/NestedKeyIterator.php
+++ b/src/StringTemplate/NestedKeyIterator.php
@@ -57,6 +57,7 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function callGetChildren()
     {
         $this->stack[] = parent::key();
@@ -66,6 +67,7 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function endChildren()
     {
         parent::endChildren();
@@ -75,6 +77,7 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $keys = $this->stack;

--- a/src/StringTemplate/RecursiveArrayOnlyIterator.php
+++ b/src/StringTemplate/RecursiveArrayOnlyIterator.php
@@ -22,6 +22,7 @@ class RecursiveArrayOnlyIterator extends \RecursiveArrayIterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function hasChildren()
     {
         return is_array($this->current()) || $this->current() instanceof \Traversable;


### PR DESCRIPTION
```
PHP Deprecated:  Return type of StringTemplate\NestedKeyIterator::key() should either be compatible with RecursiveIteratorIterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in E:\WWW\XXX\vendor\nicmart\string-template\src\StringTemplate\NestedKeyIterator.php on line 78
PHP Deprecated:  Return type of StringTemplate\NestedKeyIterator::callGetChildren() should either be compatible with RecursiveIteratorIterator::callGetChildren(): ?RecursiveIterator, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in E:\WWW\XXX\vendor\nicmart\string-template\src\StringTemplate\NestedKeyIterator.php on line 60
PHP Deprecated:  Return type of StringTemplate\NestedKeyIterator::endChildren() should either be compatible with RecursiveIteratorIterator::endChildren(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in E:\WWW\XXX\vendor\nicmart\string-template\src\StringTemplate\NestedKeyIterator.php on line 69
PHP Deprecated:  Return type of StringTemplate\RecursiveArrayOnlyIterator::hasChildren() should either be compatible with RecursiveArrayIterator::hasChildren(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in E:\WWW\XXX\vendor\nicmart\string-template\src\StringTemplate\RecursiveArrayOnlyIterator.php on line 25
```