### PR TITLE
Add type information to fix php8.1 depreciation messages

### DIFF
--- a/src/StringTemplate/Engine.php
+++ b/src/StringTemplate/Engine.php
@@ -33,7 +33,7 @@ class Engine extends AbstractEngine
             $value = array('' => $value);
 
         foreach (new NestedKeyIterator(new RecursiveArrayOnlyIterator($value)) as $key => $value) {
-            $result = str_replace($this->left . $key . $this->right, $value, $result);
+            $result = str_replace($this->left . $key . $this->right, $value??'', $result);
         }
 
         return $result;

--- a/src/StringTemplate/Engine.php
+++ b/src/StringTemplate/Engine.php
@@ -33,7 +33,10 @@ class Engine extends AbstractEngine
             $value = array('' => $value);
 
         foreach (new NestedKeyIterator(new RecursiveArrayOnlyIterator($value)) as $key => $value) {
-            $result = str_replace($this->left . $key . $this->right, $value??'', $result);
+            // only replace if $value is number, string or bool
+            if (is_scalar($value)) {
+                $result = str_replace($this->left . $key . $this->right, $value??'', $result);
+            }
         }
 
         return $result;

--- a/src/StringTemplate/NestedKeyArray.php
+++ b/src/StringTemplate/NestedKeyArray.php
@@ -28,7 +28,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new NestedKeyIterator(new RecursiveArrayOnlyIterator($this->array));
     }
@@ -36,7 +36,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         $keys = explode($this->keySeparator, $offset);
         $ary = &$this->array;
@@ -53,7 +53,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         $keys = explode($this->keySeparator, $offset);
         $result = &$this->array;
@@ -68,7 +68,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->setNestedOffset($this->array, explode($this->keySeparator, $offset), $value);
     }
@@ -76,7 +76,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         $this->unsetNestedOffset($this->array, explode($this->keySeparator, $offset));
     }

--- a/src/StringTemplate/NestedKeyIterator.php
+++ b/src/StringTemplate/NestedKeyIterator.php
@@ -57,7 +57,7 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
     /**
      * {@inheritdoc}
      */
-    public function callGetChildren()
+    public function callGetChildren(): ?\RecursiveIterator
     {
         $this->stack[] = parent::key();
         return parent::callGetChildren();
@@ -66,7 +66,7 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
     /**
      * {@inheritdoc}
      */
-    public function endChildren()
+    public function endChildren(): void
     {
         parent::endChildren();
         array_pop($this->stack);
@@ -75,7 +75,7 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
     /**
      * {@inheritdoc}
      */
-    public function key()
+    public function key(): mixed
     {
         $keys = $this->stack;
         $keys[] = parent::key();

--- a/src/StringTemplate/RecursiveArrayOnlyIterator.php
+++ b/src/StringTemplate/RecursiveArrayOnlyIterator.php
@@ -22,7 +22,7 @@ class RecursiveArrayOnlyIterator extends \RecursiveArrayIterator
     /**
      * {@inheritdoc}
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return is_array($this->current()) || $this->current() instanceof \Traversable;
     }


### PR DESCRIPTION
PHP8.1 emits a number of depreciation messages complaining about the type compatibility with function prototypes.

This PR fixed the problem by adding proper type annotations to affected functions. 