### PR TITLE
Fix deprecations messages due to type changes on PHP 8.1 & PHP 8.2

### DIFF
--- a/src/StringTemplate/NestedKeyArray.php
+++ b/src/StringTemplate/NestedKeyArray.php
@@ -28,7 +28,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new NestedKeyIterator(new RecursiveArrayOnlyIterator($this->array));
     }
@@ -36,7 +36,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $keys = explode($this->keySeparator, $offset);
         $ary = &$this->array;
@@ -53,6 +53,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $keys = explode($this->keySeparator, $offset);
@@ -68,7 +69,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->setNestedOffset($this->array, explode($this->keySeparator, $offset), $value);
     }
@@ -76,7 +77,7 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->unsetNestedOffset($this->array, explode($this->keySeparator, $offset));
     }

--- a/src/StringTemplate/NestedKeyIterator.php
+++ b/src/StringTemplate/NestedKeyIterator.php
@@ -75,6 +75,7 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $keys = $this->stack;

--- a/src/StringTemplate/NestedKeyIterator.php
+++ b/src/StringTemplate/NestedKeyIterator.php
@@ -57,7 +57,7 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
     /**
      * {@inheritdoc}
      */
-    public function callGetChildren()
+    public function callGetChildren(): ?\RecursiveIterator
     {
         $this->stack[] = parent::key();
         return parent::callGetChildren();
@@ -66,7 +66,7 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
     /**
      * {@inheritdoc}
      */
-    public function endChildren()
+    public function endChildren(): void
     {
         parent::endChildren();
         array_pop($this->stack);
@@ -82,4 +82,4 @@ class NestedKeyIterator extends \RecursiveIteratorIterator
 
         return implode($this->keySeparator, $keys);
     }
-} 
+}

--- a/src/StringTemplate/RecursiveArrayOnlyIterator.php
+++ b/src/StringTemplate/RecursiveArrayOnlyIterator.php
@@ -22,7 +22,7 @@ class RecursiveArrayOnlyIterator extends \RecursiveArrayIterator
     /**
      * {@inheritdoc}
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return is_array($this->current()) || $this->current() instanceof \Traversable;
     }


### PR DESCRIPTION
Fixes deprecation messages when running on PHP 8.1 or PHP 8.2:

- `E_DEPRECATED: Return type of StringTemplate\\NestedKeyIterator::key() should either be compatible with RecursiveIteratorIterator::key(): mixed, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`
- `E_DEPRECATED: Return type of StringTemplate\\NestedKeyIterator::callGetChildren() should either be compatible with RecursiveIteratorIterator::callGetChildren(): ?RecursiveIterator, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`
- `E_DEPRECATED: Return type of StringTemplate\\NestedKeyIterator::endChildren() should either be compatible with RecursiveIteratorIterator::endChildren(): void, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`
- `E_DEPRECATED: Return type of StringTemplate\\RecursiveArrayOnlyIterator::hasChildren() should either be compatible with RecursiveArrayIterator::hasChildren(): bool, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`