### PR TITLE
Fix PHP 8 str_replace

### DIFF
--- a/src/StringTemplate/Engine.php
+++ b/src/StringTemplate/Engine.php
@@ -33,6 +33,8 @@ class Engine extends AbstractEngine
             $value = array('' => $value);
 
         foreach (new NestedKeyIterator(new RecursiveArrayOnlyIterator($value)) as $key => $value) {
+            if ($value === null)
+                $value = '';
             $result = str_replace($this->left . $key . $this->right, $value, $result);
         }
 


### PR DESCRIPTION
Passing null to parameter #2 ($replace) of type array|string is deprecated