### PR TITLE
Support to conditions, filters (transformers/modifiers) and Closure Values

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
     
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.2', '7.4', '8.0', '8.1']
 
     steps:
     - uses: actions/checkout@v3
@@ -43,3 +43,6 @@ jobs:
 
     - name: Run test suite
       run: composer run-script test
+
+    - name: Run Benchmark suite
+      run: composer run-script bench

--- a/README.md
+++ b/README.md
@@ -78,7 +78,116 @@ $engine->render(
 ```
 
 
-### SprintfEngine
+You can use a simple condition:
+```php
+$engine = new StringTemplate\Engine();
+
+//Returns Oh! You
+$engine->render(
+    'Oh! {#name}{test}{/name}',
+    [
+        'name' => true,
+        'test' => 'You'
+    ]);
+
+```
+
+
+You can use a simple condition with else:
+```php
+$engine = new StringTemplate\Engine();
+
+//Returns Oh! My
+$engine->render(
+    'Oh! {#name}{test}{#else}My{/name}',
+    [
+        'name' => false,
+        'test' => 'You'
+    ]);
+
+```
+
+
+
+You can use a simple filters ( lower|upper|esc_html ):
+```php
+$engine = new StringTemplate\Engine();
+
+//Returns Oh! JOHN
+$engine->render(
+    'Oh! {name|upper}',
+    [
+        'name' => 'John'
+    ]);
+
+```
+
+You can add you own filters:
+```php
+$engine = new StringTemplate\Engine('{','}', [
+    'ucfist' => 'ucfirst',
+    'esc_html' =>  function($string){ return htmlentities($string, ENT_NOQUOTES); } // override a default filter
+]);
+
+//Returns Oh! &lt;script&gt;John&lt;/script&gt;'
+$engine->render(
+    'Oh! {name|esc_html}',
+    [
+        'name' => '<script>John</script>'
+    ]);
+
+```
+
+
+You can use closures a values
+```php
+$engine = new StringTemplate\Engine();
+
+//Returns Oh! John
+$engine->render(
+    'Oh! {name|upper}',
+    [
+        'name' => function() {
+            return 'John';
+        }
+    ]);
+
+```
+
+You can use closures can use the variables
+```php
+$engine = new StringTemplate\Engine();
+
+//Returns Oh! John Doe
+$engine->render(
+    'Oh! {name}',
+    [
+        'first' => 'John',
+        'last' => 'Doe',
+        'name' => function($values) {
+            return $values['first'].' '.$values['last'];
+        }
+    ]);
+
+```
+
+And lastly, you can use sprintf formats:
+ ```php
+$engine = new StringTemplate\SprintfEngine;
+
+//Returns I have 1.2 (1.230000E+0) apples.
+    $engine->render(
+        "I have {num%.1f} ({num%.6E}) {fruit}.",
+        [
+            'num' => 1.23,
+            'fruit' => 'apples'
+        ]
+    )
+
+```
+
+
+### SprintfEngine (Deprecated)
 You can use a more powerful version of the engine if you want to specify [convertion specifications](http://php.net/manual/en/function.sprintf.php) for placeholders. The conversion syntax is identical to `sprintf` one, you need only to specify the optional parameter after the placeholder name.
 
 Example:

--- a/benchmarks/engine.php
+++ b/benchmarks/engine.php
@@ -11,21 +11,20 @@
 /**
  * This is a basic benchmark test for Engine...
  */
-include '../vendor/autoload.php';
+include 'vendor/autoload.php';
 
-$engine = new \StringTemplate\Engine;
+$engine = new \StringTemplate\Engine();
 $template = "These are {foo} and {bar}. Those are {goo.b} and {goo.v} %";
 $vars = array(
     'foo' => 'bar',
     'baz' => 'friend',
     'goo' => array('a' => 'b', 'c' => 'd')
 );
-$replace = function () use ($engine, $template, $vars)
-{
+$replace = function () use ($engine, $template, $vars) {
     $engine->render($template, $vars);
 };
 
-$engineSprintf = new \StringTemplate\SprintfEngine;
+$engineSprintf = new \StringTemplate\SprintfEngine();
 $replaceSprintf = function () use ($engineSprintf, $template, $vars) {
     $engineSprintf->render($template, $vars);
 };
@@ -34,8 +33,8 @@ $templateSprintf = "These are %s and %s. Those are %s and %s";
 $varsSprintf = array(
     'bar', 'friend', 'b', 'd'
 );
-$sprintf = function () use ($template, $varsSprintf)
-{
+
+$sprintf = function () use ($template, $varsSprintf) {
     $args = array_merge(array($template), $varsSprintf);
     call_user_func_array('sprintf', $args);
 };
@@ -47,31 +46,31 @@ $varsReplace = array(
     'bar', 'friend', 'b', 'd'
 );
 
-$strReplace = function () use ($template, $varsSearch, $varsReplace)
-{
+$strReplace = function () use ($template, $varsSearch, $varsReplace) {
     str_replace($varsSearch, $varsReplace, $template);
 };
 
 function benchmark($f, $title = '', $iterations = 100000)
 {
     static $firstTime = 0;
-    echo '<br><b>', $title, '</b><br>';
+    echo "\n\n======", $title, "=======\n";
     $start = microtime(true);
-    for ($i = 0; $i < $iterations; $i++)
+    for ($i = 0; $i < $iterations; $i++) {
         $f();
+    }
     $time = microtime(true) - $start;
-    echo 'Time: ', $time, '<br>';
+    echo 'Time: ', $time, "\n";
     if ($firstTime) {
         echo 'Factor: ', sprintf("%d.3&times;", $time / $firstTime);
-        echo ', Reverse Factor: ', sprintf("%d.3&times;", $firstTime / $time), '<br>';
+        echo ', Reverse Factor: ', sprintf("%d.3&times;", $firstTime / $time), "\n";
     } else {
         $firstTime = $time;
     }
-    echo 'Average: ', $time / $iterations, '<br>';
+    echo 'Average: ', $time / $iterations, "\n";
     echo 'MemoryPeak: ', memory_get_peak_usage(), ' (meaningful only if you run one benchmark at time)';
 }
 
 benchmark($replace, 'Engine benchmark');
 benchmark($replaceSprintf, 'Engine Sprintf benchmark');
-benchmark($sprintf, 'Sprintf benchmark');
+//benchmark($sprintf, 'Sprintf benchmark');
 benchmark($strReplace, 'StrReplace benchmark');

--- a/benchmarks/engine.php
+++ b/benchmarks/engine.php
@@ -14,11 +14,11 @@
 include 'vendor/autoload.php';
 
 $engine = new \StringTemplate\Engine();
-$template = "These are {foo} and {bar}. Those are {goo.b} and {goo.v} %";
+$template = "These are {foo} and {bar}. Those are {goo.b} and {goo.v}  {goo.e%E} %";
 $vars = array(
     'foo' => 'bar',
     'baz' => 'friend',
-    'goo' => array('a' => 'b', 'c' => 'd')
+    'goo' => array('a' => 'b', 'c' => 'd' , 'e' => 12.4 )
 );
 $replace = function () use ($engine, $template, $vars) {
     $engine->render($template, $vars);
@@ -40,10 +40,10 @@ $sprintf = function () use ($template, $varsSprintf) {
 };
 
 $varsSearch = array(
-    'foo', 'baz', 'goo.a', 'goo.c'
+    'foo', 'baz', 'goo.a', 'goo.c' , 'goo.e%E'
 );
 $varsReplace = array(
-    'bar', 'friend', 'b', 'd'
+    'bar', 'friend', 'b', 'd' , '12.4'
 );
 
 $strReplace = function () use ($template, $varsSearch, $varsReplace) {

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
     {
       "name": "Nicolò Martini",
       "email": "nicmartnic@gmail.com"
+    }, 
+    {
+      "name": "Rahal Aboulfeth",
+      "email": "rahal.aboulfeth@gmail.com"
     }
   ],
   "require": {
@@ -17,7 +21,8 @@
     "phpunit/phpunit": "^8 || ^9"
   },
   "scripts": {
-    "test": "vendor/bin/phpunit"
+    "test": "vendor/bin/phpunit",
+    "bench": "php benchmarks/engine.php"
   },
   "autoload": {
     "psr-4": {

--- a/src/StringTemplate/Engine.php
+++ b/src/StringTemplate/Engine.php
@@ -125,7 +125,7 @@ class Engine
 
             if (isset($nestedKeyArray[$toEvaluate])) {
                 $result = isset($matches[2]) && $matches[2] ? sprintf($matches[2], $nestedKeyArray[$toEvaluate]) : $nestedKeyArray[$toEvaluate] ;
-                // Handle filters (modifiers) is
+                // Handle filters (modifiers)
                 if (isset($matches[3]) && isset($matches[4])) {
                     $filter = $matches[4];
                     if (isset($this->allowedFilters[$filter]) &&  is_callable($this->allowedFilters[$filter])) {

--- a/src/StringTemplate/Engine.php
+++ b/src/StringTemplate/Engine.php
@@ -19,22 +19,125 @@ namespace StringTemplate;
  * <code>
  * $engine->render('This is {a} and these are {c.0} and {c.1}', ['a' => 'b', 'c' => ['d', 'e']]);
  * //Prints "This is b and these are d and e"
+  * $engine->render('Oh! {#name}{test}{/name}', ['name' => true, 'test' => 'Me']);
+ * //Prints "'Oh! Me'"
  * </code>
  */
-class Engine extends AbstractEngine
+class Engine
 {
+    protected $left;
+    protected $right;
+    protected $ifRegex;
+    protected $varRegex;
+    protected $defaultFilters = [
+        'upper' => 'strtoupper',
+        'lower' => 'strtolower',
+        'esc_html' => 'htmlspecialchars'
+
+    ];
+
+
     /**
-     * {@inheritdoc}
+     * @param string $left  The left delimiter
+     * @param string $right The right delimiter
+     * @param array $filters allowed filters
+     */
+    public function __construct($left = '{', $right = '}', $filters = [])
+    {
+        $this->left = preg_quote($left, '/');
+        $this->right = preg_quote($right, '/');
+        $this->ifRegex = $this->ifRegex();
+        $this->varRegex = $this->varRegex();
+        $this->allowedFilters = array_merge($this->defaultFilters, $filters);
+    }
+
+    /**
+     * If regular expression
+     * greps {#variablename}if true{/variablename}
+     * and {#variablename}if true{#else) if false {/variablename}
+     * @return     string  The regex
+     */
+    public function ifRegex()
+    {
+        return '/'.$this->left.'#([a-zA-Z0-9_.-]*)'.$this->right. // If {#variable}
+            '(.+?)'. // Inside condition tag
+            '('.$this->left.'#else'.$this->right.'(.+?))?'. // maybe {#else} tag and condition
+            $this->left.'\/\1'.$this->right.'/'; // close if {/variable}
+        return $reg;
+    }
+
+    /**
+     * Variable Regex
+     * greps {variablename}
+     * or {variablename%format}
+     * or {variablename|filter}
+     * or {variablename%format|filter}
+     * @return     string  The regex
+     */
+    public function varRegex()
+    {
+        return '/'.$this->left.
+            '([a-zA-Z0-9_.-]*)'.  // The variable
+            '(%[^' .($this->right ? $this->right : ' ') . ']+)?' . // maybe sprintf format
+            '(\|([a-zA-Z0-9_]+))?'. // maybe simple filter
+            $this->right.'/';
+    }
+
+    /**
+     * @param string $template      The template string
+     * @param string|array|NestedKeyArray $value   The value the template will be rendered with
+     *
+     * @return string The rendered template
      */
     public function render($template, $value)
     {
         $result = $template;
-        if (!is_array($value))
-            $value = array('' => $value);
 
-        foreach (new NestedKeyIterator(new RecursiveArrayOnlyIterator($value)) as $key => $value) {
-            $result = str_replace($this->left . $key . $this->right, $value, $result);
+        if ($value instanceof NestedKeyArray) {
+            $nestedKeyArray = $value;
+        } else {
+            if (!is_array($value)) {
+                $value = array('' => $value);
+            }
+            $nestedKeyArray = new NestedKeyArray($value) ;
         }
+
+        // handle if regex
+        $result = preg_replace_callback($this->ifRegex, function ($matches) use ($nestedKeyArray) {
+            $toEvaluate = $matches[1];
+            $inside = $matches[2];
+
+            if (isset($nestedKeyArray[$toEvaluate])) {
+                if ($nestedKeyArray[$toEvaluate]) {
+                    return $this->render($inside, $nestedKeyArray);
+                }
+            }
+
+            $hasElse = isset($matches[3]) ? $matches[3] : false ;
+            if ($hasElse && isset($matches[4])) {
+                return $this->render($matches[4], $nestedKeyArray);
+            }
+        }, $result);
+
+        // handle variables replacement
+        $result = preg_replace_callback($this->varRegex, function ($matches) use ($nestedKeyArray) {
+            $toEvaluate = $matches[1];
+
+            if (isset($nestedKeyArray[$toEvaluate])) {
+                $result = isset($matches[2]) && $matches[2] ? sprintf($matches[2], $nestedKeyArray[$toEvaluate]) : $nestedKeyArray[$toEvaluate] ;
+                // Handle filters (modifiers) is
+                if (isset($matches[3]) && isset($matches[4])) {
+                    $filter = $matches[4];
+                    if (isset($this->allowedFilters[$filter]) &&  is_callable($this->allowedFilters[$filter])) {
+                        $result = $this->allowedFilters[$filter]($result);
+                    } else {
+                        throw new \Exception("Filter $filter not allowed");
+                    }
+                }
+                return $result;
+            }
+            return $matches[0];
+        }, $result);
 
         return $result;
     }

--- a/src/StringTemplate/Engine.php
+++ b/src/StringTemplate/Engine.php
@@ -62,7 +62,7 @@ class Engine
         return '/'.$this->left.'#([a-zA-Z0-9_.-]*)'.$this->right. // If {#variable}
             '(.+?)'. // Inside condition tag
             '('.$this->left.'#else'.$this->right.'(.+?))?'. // maybe {#else} tag and condition
-            $this->left.'\/\1'.$this->right.'/'; // close if {/variable}
+            $this->left.'\/\1'.$this->right.'/si'; // close if {/variable}
         return $reg;
     }
 

--- a/src/StringTemplate/NestedKeyArray.php
+++ b/src/StringTemplate/NestedKeyArray.php
@@ -11,6 +11,8 @@
 
 namespace StringTemplate;
 
+use Closure;
+
 class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
 {
     private $array;
@@ -43,8 +45,9 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
         $ary = &$this->array;
 
         foreach ($keys as $key) {
-            if (!isset($ary[$key]))
+            if (!isset($ary[$key])) {
                 return false;
+            }
             $ary = &$ary[$key];
         }
 
@@ -62,6 +65,11 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
 
         foreach ($keys as $key) {
             $result = &$result[$key];
+        }
+
+        // If is callable
+        if ($result instanceof Closure) {
+            return $result($this);
         }
 
         return $result;
@@ -105,8 +113,9 @@ class NestedKeyArray implements \ArrayAccess, \IteratorAggregate
         if (!$offsets) {
             $target[$currKey] = $value;
         } else {
-            if (!isset($target[$currKey]))
+            if (!isset($target[$currKey])) {
                 $target[$currKey] = array();
+            }
             $this->setNestedOffset($target[$currKey], $offsets, $value);
         }
 

--- a/tests/StringTemplate/EngineTest.php
+++ b/tests/StringTemplate/EngineTest.php
@@ -99,10 +99,12 @@ class EngineTest extends TestCase
             )
         );
 
+        // test multiline
         $this->assertEquals(
-            'Oh! Them',
+            "Oh! Them\n",
             $engine->render(
-                'Oh! {#name.value}{test}{#else}{#content}Them{/content}{/name.value}',
+                "Oh! {#name.value}
+                {test}{#else}{#content}Them{/content}\n{/name.value}",
                 array(
                     'name' => ['value' => false] ,
                     'test' => 'Me',

--- a/tests/StringTemplate/EngineTest.php
+++ b/tests/StringTemplate/EngineTest.php
@@ -40,16 +40,222 @@ class EngineTest extends TestCase
         );
     }
 
+    public function testRenderWithCondition()
+    {
+        $engine = new Engine();
+        $this->assertEquals(
+            'Oh! Me',
+            $engine->render(
+                'Oh! {#name}Me{/name}',
+                array(
+                    'name' => true
+                )
+            )
+        );
+        $this->assertEquals(
+            'Oh! Me',
+            $engine->render(
+                'Oh! {#name.value}Me{/name.value}',
+                array(
+                    'name' => ['value'=>true]
+                )
+            )
+        );
+        $this->assertEquals(
+            'Oh! Me',
+            $engine->render(
+                'Oh! {#name}{test}{/name}',
+                array(
+                    'name' => function () {
+                        return true;
+                    },
+                    'test' => 'Me'
+                )
+            )
+        );
+
+        $this->assertTrue(is_callable('strtoupper'));
+        $this->assertEquals(
+            'Oh! strtoupper',
+            $engine->render(
+                'Oh! {#name}{test}{#else}{else}{/name}',
+                array(
+                    'name' => false ,
+                    'test' => 'Me',
+                    'else' => 'strtoupper'
+                )
+            )
+        );
+
+        $this->assertEquals(
+            'Oh! Him',
+            $engine->render(
+                'Oh! {#name.value}{test}{#else}{else.content}{/name.value}',
+                array(
+                    'name' => ['value' => false] ,
+                    'test' => 'Me',
+                    'else' => [ 'content' => 'Him']
+                )
+            )
+        );
+
+        $this->assertEquals(
+            'Oh! Them',
+            $engine->render(
+                'Oh! {#name.value}{test}{#else}{#content}Them{/content}{/name.value}',
+                array(
+                    'name' => ['value' => false] ,
+                    'test' => 'Me',
+                    'content' => 'Him'
+                )
+            )
+        );
+    }
+
+    public function testNoRightDelimiter()
+    {
+        $engine = new Engine(':', '');
+        $this->assertEquals(
+            'Oh! Me',
+            $engine->render(
+                'Oh! :name',
+                array(
+                    'name' => 'Me'
+                )
+            )
+        );
+
+        $this->assertEquals(
+            'Oh! Him',
+            $engine->render(
+                'Oh! :#nameHim:/name',
+                array(
+                    'name' => true
+                )
+            )
+        );
+
+        $this->assertEquals(
+            'Oh! Them',
+            $engine->render(
+                'Oh! :#name.value:test:#else:#contentThem:/content:/name.value',
+                array(
+                    'name' => ['value' => false] ,
+                    'test' => 'Me',
+                    'content' => 'Him'
+                )
+            )
+        );
+    }
+
+
+
+    public function testSprintf()
+    {
+        $engine = new Engine();
+        $this->assertEquals(
+            sprintf('Oh! %s %s jumped onto %s (%e) table', 'The', 'cat', 1, 1),
+            $engine->render(
+                'Oh! {subj.det%s} {subj.np%s} {verb} onto {w.where.number%s} ({w.where.number%e}) {w.where.np}',
+                array(
+                    'verb' => 'jumped',
+                    'subj' => array('det' => 'The', 'np' => 'cat'),
+                    'w' => array('where' => array('number' => 1, 'np' => 'table'))
+                )
+            )
+        );
+    }
+
+     public function testClosure()
+     {
+         $engine = new Engine();
+         $this->assertEquals(
+             'Oh John Doe',
+             $engine->render(
+                 'Oh {name}',
+                 [
+                     'first' => 'John',
+                     'last' => 'Doe',
+                     'name' => function ($values) {
+                         return $values['first'].' '.$values['last'];
+                     }
+                 ]
+             )
+         );
+     }
+
+
+    public function testModifier()
+    {
+        $engine = new Engine(':', '');
+        $this->assertEquals(
+            'Oh! ME',
+            $engine->render(
+                'Oh! :name|upper',
+                array(
+                    'name' => 'Me'
+                )
+            )
+        );
+
+        try {
+            $engine->render(
+                'Oh! :name|strtoupper',
+                array(
+                    'name' => 'Me'
+                )
+            );
+        } catch (\Exception $e) {
+            $this->assertEquals($e->getMessage(), "Filter strtoupper not allowed");
+        }
+    }
+
+
+
+    public function testCustomModifier()
+    {
+        $engine = new Engine(':', '', [
+            'esc_html' => function ($string) {
+                return htmlentities($string, ENT_NOQUOTES);
+            }
+        ]);
+        $this->assertEquals(
+            'Oh! &lt;script&gt;John&lt;/script&gt;',
+            $engine->render(
+                'Oh! :name|esc_html',
+                array(
+                    'name' =>  '<script>John</script>'
+                )
+            )
+        );
+    }
+
+    public function testFixRegSprintfGlutony()
+    {
+        $engine = new Engine();
+        $this->assertEquals(
+            'These are bar and friend. Those are {goo.b} and {goo.v} %',
+            $engine->render(
+                'These are {foo} and {bar}. Those are {goo.b} and {goo.v} %',
+                array(
+                   'foo' => 'bar',
+                   'bar' => 'friend',
+                   'goo' => array('a' => 'b', 'c' => 'd')
+                )
+            )
+        );
+    }
+
     public function testRenderWithObjectValues()
     {
-        $engine = new Engine;
+        $engine = new Engine();
         $this->assertEquals('foo', $engine->render('{value}', array('value' => new ObjectMock())));
     }
 }
 
 class ObjectMock
 {
-    function __toString()
+    public function __toString()
     {
         return 'foo';
     }


### PR DESCRIPTION
Hello, first of all, thank you for this lightweight template library, I needed some more features as I plan to use it in my wordpress plugin ["Mail Control"](https://fr.wordpress.org/plugins/mail-control/) .

Would be happy to get your feedback about them : 

- Add support to simple conditions :
	- {#name}if true{/name}
	- {#name}if true{#else}if false{/name}
	- {#name}if true {variable}{#else}if false{other_variable}{/name}
- Add support to simple filters ( transformers/modifiers ) :
	- {variable|upper} , {variable|lower}, {variable|esc_html}
	- Allow defining additionnal/override filters in constructor
- Add support to Closure Values
- Updated Readme and composer file (bench command)